### PR TITLE
Handling error messages

### DIFF
--- a/src/ApiClient.php
+++ b/src/ApiClient.php
@@ -61,10 +61,16 @@ class ApiClient extends AbstractApiClient
      */
     protected function processErrorResponse(ResponseInterface $response, RequestInterface $request)
     {
-        if (($responseBody = json_decode($response->getBody()->getContents(), true)) &&
-            array_key_exists('message', $responseBody)
+        if (($responseBody = json_decode($response->getBody()->__toString(), true)) &&
+            (array_key_exists('message', $responseBody))
         ) {
             throw new ErrorResponseException($responseBody['message'], $response->getStatusCode());
+        }
+
+        if (($responseBody = json_decode($response->getBody()->__toString(), true)) &&
+            (array_key_exists('error', $responseBody))
+        ) {
+            throw new ErrorResponseException($responseBody['error'], $response->getStatusCode());
         }
     }
 }

--- a/src/ApiClient.php
+++ b/src/ApiClient.php
@@ -61,16 +61,14 @@ class ApiClient extends AbstractApiClient
      */
     protected function processErrorResponse(ResponseInterface $response, RequestInterface $request)
     {
-        if (($responseBody = json_decode($response->getBody()->__toString(), true)) &&
-            (array_key_exists('message', $responseBody))
-        ) {
-            throw new ErrorResponseException($responseBody['message'], $response->getStatusCode());
-        }
+        if ($responseBody = json_decode($response->getBody()->getContents(), true)) {
+            if (array_key_exists('message', $responseBody)) {
+                throw new ErrorResponseException($responseBody['message'], $response->getStatusCode());
+            }
 
-        if (($responseBody = json_decode($response->getBody()->__toString(), true)) &&
-            (array_key_exists('error', $responseBody))
-        ) {
-            throw new ErrorResponseException($responseBody['error'], $response->getStatusCode());
+            if (array_key_exists('error', $responseBody)) {
+                throw new ErrorResponseException($responseBody['error'], $response->getStatusCode());
+            }
         }
     }
 }


### PR DESCRIPTION
### Changed
 - *error* messages are now handled in the API client (147758423)

`Paybreak/merchant-api` will need to be updated

[Delivers #147758423](https://www.pivotaltracker.com/story/show/147758423)

